### PR TITLE
Fix spelling

### DIFF
--- a/tooling/support/build.gradle
+++ b/tooling/support/build.gradle
@@ -26,7 +26,7 @@ gradlePlugin {
             displayName = findProperty("libraryName")?.toString()
             description = findProperty("description")?.toString()
             tags.addAll("affected-paths")
-            implementationClass = "com.squareup.tooling.suppport.SquareToolingPlugin"
+            implementationClass = "com.squareup.tooling.support.SquareToolingPlugin"
         }
     }
 }


### PR DESCRIPTION
Otherwise we get an error using the plugin:

```
plugins {
    id 'com.squareup.tooling' version '0.0.3'
}
```

```
Caused by: org.gradle.api.plugins.InvalidPluginException: Could not find implementation class 'com.squareup.tooling.suppport.SquareToolingPlugin' for plugin 'com.squareup.tooling' specified in jar:file:/Users/rogerh/.gradle/caches/jars-8/0cc82038820e78403bd883eaac13d5d8/tooling-support-0.0.3.jar!/META-INF/gradle-plugins/com.squareup.tooling.properties.
	at org.gradle.api.internal.plugins.DefaultPluginRegistry$1.load(DefaultPluginRegistry.java:74)
	at org.gradle.api.internal.plugins.DefaultPluginRegistry$1.load(DefaultPluginRegistry.java:52)
```

It works with the legacy mode because the implementationClass doesn't get used.
