### PR TITLE
Auto-inject plugin by default

### DIFF
--- a/affected-paths/app/CHANGELOG.md
+++ b/affected-paths/app/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Affected-Paths
 
 ## Unreleased
+- Adds in `--inject-plugin` flag to auto-inject plugin to any build
+
+## v0.0.1
 - Initial Release

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
@@ -105,4 +105,11 @@ internal class BaseConfigurationOptions {
   )
   var maxGradleMemory: Int? = null
     internal set
+
+  @Option(
+    names = ["--inject-plugin"],
+    description = ["Injects the \"com.squareup.tooling\" plugin to all projects in the build"]
+  )
+  var autoInject: Boolean = false
+    internal set
 }

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
@@ -30,6 +30,7 @@ internal fun BaseConfigurationOptions.toCoreOptions(): CoreOptions {
     initialGradleMemory = initialGradleMemory,
     maxGradleMemory = maxGradleMemory,
     customJvmFlags = listOf("-XX:-MaxFDLimit"),
-    customGradleFlags = listOf("--stacktrace")
+    customGradleFlags = listOf("--stacktrace"),
+    autoInjectPlugin = autoInject
   )
 }

--- a/affected-paths/core/CHANGELOG.md
+++ b/affected-paths/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Affected-Paths Core
 
 ## Unreleased
+- Adds `autoInjectPlugin` flag to `CoreOptions`, which auto-injects the "com.squareup.tooling" plugin to the build
 
 ## v0.1.0
 - Initial public release

--- a/affected-paths/core/gradle.properties
+++ b/affected-paths/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1
 
 POM_ARTIFACT_ID=affected-paths-core
 POM_NAME=Affected-Paths Core

--- a/affected-paths/core/gradle.properties
+++ b/affected-paths/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.1
+VERSION_NAME=0.1.0
 
 POM_ARTIFACT_ID=affected-paths-core
 POM_NAME=Affected-Paths Core

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
@@ -94,20 +94,21 @@ public data class CoreOptions @JvmOverloads constructor(
         File.createTempFile("tempScript", ".gradle").apply {
           writeText(
             """
-                allprojects {
-                  buildscript {
-                    repositories {
-                      mavenCentral()
-                    }
-                    dependencies {
-                      classpath "com.squareup.affected.paths:tooling-support:0.1.0"
-                    }
+              beforeProject { project ->
+                project.buildscript {
+                  repositories {
+                    mavenCentral()
                   }
-                  
-                  afterEvaluate { p ->
-                    p.apply plugin: "com.squareup.tooling"
+                  dependencies {
+                    classpath "com.squareup.affected.paths:tooling-support:0.1.0"
                   }
                 }
+              }
+              afterProject { project ->
+                if (!project.plugins.hasPlugin("com.squareup.tooling")) {
+                  project.apply plugin: "com.squareup.tooling"
+                }
+              }
             """.trimIndent()
           )
           deleteOnExit()

--- a/tooling/support/CHANGELOG.md
+++ b/tooling/support/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Tooling-Support
 
 ## Unreleased
+- Fix crash from `SquareProjectModelBuilder` when used on a non-Java/Android project 
 
 ## v0.1.0
 - Initial public release

--- a/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
+++ b/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
@@ -42,10 +42,9 @@ private class SquareProjectModelBuilderImpl : SquareProjectModelBuilder {
     return modelName == SquareProject::class.java.name
   }
 
-  override fun buildAll(modelName: String, project: Project): Any {
+  override fun buildAll(modelName: String, project: Project): Any? {
     if (modelName == SquareProject::class.java.name) {
       return extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }
-        ?: throw IllegalArgumentException("No known plugin used (should be Android or Java)")
     }
 
     // If this is used for any other project types, or for some other model type,

--- a/tooling/support/src/test/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilderTest.kt
+++ b/tooling/support/src/test/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilderTest.kt
@@ -24,6 +24,7 @@ import com.squareup.tooling.models.SquareProject
 import com.squareup.tooling.support.core.models.SquareDependency
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertContains
@@ -288,15 +289,13 @@ class SquareProjectModelBuilderTest {
   }
 
   @Test
-  fun `Ensure no plugins throws exception`() {
+  fun `Do not throw exception if a non-Java or non-Android plugin is used`() {
     val projectModelBuilder = SquareProjectModelBuilder()
 
     val project = ProjectBuilder.builder().build()
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    assertDoesNotThrow {
       projectModelBuilder.buildAll(SquareProject::class.java.name, project)
     }
-
-    assertEquals("No known plugin used (should be Android or Java)", exception.message)
   }
 }


### PR DESCRIPTION
- Auto-inject tooling plugin to all projects in Gradle build by default.
- Update README.md to provide more context and a few more examples.
- Update demo app to use auto-inject feature.