### PR TITLE
Release core v0.1.1 and tooling-support v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The affected-paths library can be found on [MavenCentral][1]:
 ### Gradle
 Groovy
 ```groovy
-implementation 'com.squareup.affected.paths:affected-paths-core:0.1.0'
+implementation 'com.squareup.affected.paths:affected-paths-core:0.1.1'
 ```
 
 Kotlin
 ```kotlin
-implementation("com.squareup.affected.paths:affected-paths-core:0.1.0")
+implementation("com.squareup.affected.paths:affected-paths-core:0.1.1")
 ```
 
 ### Maven
@@ -61,7 +61,7 @@ implementation("com.squareup.affected.paths:affected-paths-core:0.1.0")
 <dependency>
   <groupId>com.squareup.affected.paths</groupId>
   <artifactId>affected-paths-core</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
 </dependency>
 ```
 
@@ -123,7 +123,7 @@ If the auto-inject flag is disabled, the tooling plugin will have to be applied 
 Gradle DSL
 ```groovy
 plugins {
-  id 'com.squareup.tooling' version '0.1.0'
+  id 'com.squareup.tooling' version '0.1.1'
 }
 ```
 
@@ -131,14 +131,12 @@ Legacy
 ```groovy
 buildscript {
   dependencies {
-    classpath "com.squareup.affected.paths:tooling-support:0.1.0"
+    classpath "com.squareup.affected.paths:tooling-support:0.1.1"
   }
 }
 
 apply plugin: "com.squareup.tooling"
 ```
-
-**WARNING:** Do not apply the plugin if the auto-inject flag is enabled. The analysis will fail due to the same plugin being applied twice.
 
 ## License
 ```

--- a/affected-paths/app/CHANGELOG.md
+++ b/affected-paths/app/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Affected-Paths
 
 ## Unreleased
+
+## v0.1.0
 - Adds in `--inject-plugin` flag to auto-inject plugin to any build
 
 ## v0.0.1

--- a/affected-paths/app/CHANGELOG.md
+++ b/affected-paths/app/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Affected-Paths
 
 ## Unreleased
+- Adds in `--inject-plugin` flag to auto-inject plugin to any build
+
+## v0.0.1
 - Initial Release

--- a/affected-paths/app/gradle.properties
+++ b/affected-paths/app/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.0.1
+version = 0.1.0

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
@@ -105,4 +105,11 @@ internal class BaseConfigurationOptions {
   )
   var maxGradleMemory: Int? = null
     internal set
+
+  @Option(
+    names = ["--inject-plugin"],
+    description = ["Injects the \"com.squareup.tooling\" plugin to all projects in the build"]
+  )
+  var autoInject: Boolean = false
+    internal set
 }

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
@@ -30,6 +30,7 @@ internal fun BaseConfigurationOptions.toCoreOptions(): CoreOptions {
     initialGradleMemory = initialGradleMemory,
     maxGradleMemory = maxGradleMemory,
     customJvmFlags = listOf("-XX:-MaxFDLimit"),
-    customGradleFlags = listOf("--stacktrace")
+    customGradleFlags = listOf("--stacktrace"),
+    autoInjectPlugin = autoInject
   )
 }

--- a/affected-paths/core/CHANGELOG.md
+++ b/affected-paths/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Affected-Paths Core
 
 ## Unreleased
+- Adds `autoInjectPlugin` flag to `CoreOptions`, which auto-injects the "com.squareup.tooling" plugin to the build
 
 ## v0.1.0
 - Initial public release

--- a/affected-paths/core/CHANGELOG.md
+++ b/affected-paths/core/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Affected-Paths Core
 
 ## Unreleased
+
+## v0.1.1
 - Adds `autoInjectPlugin` flag to `CoreOptions`, which auto-injects the "com.squareup.tooling" plugin to the build
 
 ## v0.1.0

--- a/affected-paths/core/gradle.properties
+++ b/affected-paths/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1
 
 POM_ARTIFACT_ID=affected-paths-core
 POM_NAME=Affected-Paths Core

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
@@ -100,7 +100,7 @@ public data class CoreOptions @JvmOverloads constructor(
                     mavenCentral()
                   }
                   dependencies {
-                    classpath "com.squareup.affected.paths:tooling-support:0.1.0"
+                    classpath "com.squareup.affected.paths:tooling-support:0.1.1"
                   }
                 }
               }

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
@@ -17,6 +17,7 @@
 
 package com.squareup.affected.paths.core
 
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.isDirectory
@@ -26,7 +27,7 @@ import kotlin.io.path.isDirectory
  * and applied to all commands.
  */
 @Suppress("unused")
-public data class CoreOptions(
+public data class CoreOptions @JvmOverloads constructor(
   /** Log Gradle build output */
   val logGradle: Boolean = false,
 
@@ -61,7 +62,10 @@ public data class CoreOptions(
   val customGradleFlags: List<String> = emptyList(),
 
   /** List of changed files to evaluate. If empty, internal Git tool is used to determine changed files */
-  val changedFiles: List<String> = emptyList()
+  val changedFiles: List<String> = emptyList(),
+
+  /** Auto-injects the "com.squareup.tooling" plugin to all projects in the build */
+  val autoInjectPlugin: Boolean = true
 ) {
 
   init {
@@ -83,5 +87,33 @@ public data class CoreOptions(
     }
   }
 
-  internal val gradleArgs: List<String> = customGradleFlags.toList()
+  internal val gradleArgs: List<String> = buildList {
+    if (autoInjectPlugin) {
+      add("-I")
+      add(
+        File.createTempFile("tempScript", ".gradle").apply {
+          writeText(
+            """
+              beforeProject { project ->
+                project.buildscript {
+                  repositories {
+                    mavenCentral()
+                  }
+                  dependencies {
+                    classpath "com.squareup.affected.paths:tooling-support:0.1.0"
+                  }
+                }
+              }
+              afterProject { project ->
+                if (!project.plugins.hasPlugin("com.squareup.tooling")) {
+                  project.apply plugin: "com.squareup.tooling"
+                }
+              }
+            """.trimIndent()
+          )
+          deleteOnExit()
+        }.absolutePath
+      )
+    }
+  }
 }

--- a/tooling/support/CHANGELOG.md
+++ b/tooling/support/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Tooling-Support
 
 ## Unreleased
+
+## v0.1.1
 - Fix crash from `SquareProjectModelBuilder` when used on a non-Java/Android project 
 
 ## v0.1.0

--- a/tooling/support/CHANGELOG.md
+++ b/tooling/support/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Tooling-Support
 
 ## Unreleased
+- Fix crash from `SquareProjectModelBuilder` when used on a non-Java/Android project 
 
 ## v0.1.0
 - Initial public release

--- a/tooling/support/gradle.properties
+++ b/tooling/support/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.0
+VERSION_NAME=0.1.1
 
 POM_ARTIFACT_ID=tooling-support
 POM_NAME=Affected-Paths Tooling Plugin

--- a/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
+++ b/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
@@ -42,10 +42,9 @@ private class SquareProjectModelBuilderImpl : SquareProjectModelBuilder {
     return modelName == SquareProject::class.java.name
   }
 
-  override fun buildAll(modelName: String, project: Project): Any {
+  override fun buildAll(modelName: String, project: Project): Any? {
     if (modelName == SquareProject::class.java.name) {
       return extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }
-        ?: throw IllegalArgumentException("No known plugin used (should be Android or Java)")
     }
 
     // If this is used for any other project types, or for some other model type,

--- a/tooling/support/src/test/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilderTest.kt
+++ b/tooling/support/src/test/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilderTest.kt
@@ -24,6 +24,7 @@ import com.squareup.tooling.models.SquareProject
 import com.squareup.tooling.support.core.models.SquareDependency
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertContains
@@ -288,15 +289,13 @@ class SquareProjectModelBuilderTest {
   }
 
   @Test
-  fun `Ensure no plugins throws exception`() {
+  fun `Do not throw exception if a non-Java or non-Android plugin is used`() {
     val projectModelBuilder = SquareProjectModelBuilder()
 
     val project = ProjectBuilder.builder().build()
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    assertDoesNotThrow {
       projectModelBuilder.buildAll(SquareProject::class.java.name, project)
     }
-
-    assertEquals("No known plugin used (should be Android or Java)", exception.message)
   }
 }


### PR DESCRIPTION
Changes:

- App:
  - Adds in `--inject-plugin` flag to auto-inject plugin to any build
- Core:
  - Adds `autoInjectPlugin` flag to `CoreOptions`, which auto-injects the "com.squareup.tooling" plugin to the build
- Tooling-Support:
  - Fix crash from `SquareProjectModelBuilder` when used on a non-Java/Android project