### PR TITLE
Improper project mapping for file changes in nested projects

### DIFF
--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/utils/DependencyUtils.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/utils/DependencyUtils.kt
@@ -117,10 +117,11 @@ private fun filesToProjects(
   val fileToDocsMap = hashMapOf<String, MutableSet<SquareProject>>()
   val list = changedFiles.mapNotNull { file ->
     val modulePath = arrayListOf<String>()
-    val doc = file.trim('/').split('/').firstNotNullOfOrNull { element ->
+    val docSet = file.trim('/').split('/').mapNotNull docSet@ { element ->
       modulePath.add(element)
-      return@firstNotNullOfOrNull projects[modulePath.joinToString("/")]
-    } ?: return@mapNotNull null
+      return@docSet projects[modulePath.joinToString("/")]
+    }
+    val doc = docSet.lastOrNull() ?: return@mapNotNull null
     return@mapNotNull file to doc
   }
 


### PR DESCRIPTION
In cases where there are nested projects, the parent project was being mapped for changes made in a child project. The logic previously returned the first project that mapped the changed file path, however it will now map to the last project mapped instead.