### PR TITLE
Evaluate projects with `com.android.test` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - `affected-paths-core`: Fix custom Gradle flags not being properly set
+- `tooling-support-android`: Evaluate projects with `com.android.test` plugin
 
 ## v0.1.2
 - `affected-paths-core`, `tooling-support-*`: Add in support for composite builds being analyzed

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
@@ -115,7 +115,8 @@ internal class BaseConfigurationOptions {
 
   @Option(
     names = ["--changed-files"],
-    description = ["List of changed files to use instead of the Git diff"]
+    description = ["List of changed files to use instead of the Git diff"],
+    split = " "
   )
   var changedFiles: List<String> = emptyList()
     internal set

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
@@ -108,7 +108,7 @@ public data class CoreOptions @JvmOverloads constructor(
                     mavenCentral()
                   }
                   dependencies {
-                    classpath "com.squareup.affected.paths:tooling-support:0.1.2"
+                    classpath "com.squareup.affected.paths:tooling-support:0.1.3"
                   }
                 }
               }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.code.style=official
 
 GROUP=com.squareup.affected.paths
-VERSION_NAME=0.1.2
+VERSION_NAME=0.1.3
 
 POM_URL=https://github.com/squareup/affected-paths
 POM_SCM_URL=https://github.com/squareup/affected-paths

--- a/test-support/src/main/kotlin/com/squareup/test/support/AndroidTestUtils.kt
+++ b/test-support/src/main/kotlin/com/squareup/test/support/AndroidTestUtils.kt
@@ -63,3 +63,25 @@ public fun generateLibraryBuild(temporaryFolder: File): File {
   }
   return buildDirectory
 }
+
+// Helper function for generating a bare-bone Android test project
+public fun generateTestBuild(temporaryFolder: File): File {
+  val buildDirectory = temporaryFolder.canonicalFile.apply { mkdirs() }
+  File(buildDirectory, "build.gradle").apply {
+    writeText("""
+        apply plugin: 'com.android.test'
+        apply plugin: 'kotlin-android'
+
+        android {
+            targetProjectPath = ":app"
+            namespace 'com.squareup.test.library'
+            compileSdk 33
+            defaultConfig {
+                targetSdk 17
+                minSdk 17
+            }
+        }
+      """.trimIndent())
+  }
+  return buildDirectory
+}

--- a/tooling/support/android/src/main/kotlin/com/squareup/tooling/support/android/SquareProjectExtractorImpl.kt
+++ b/tooling/support/android/src/main/kotlin/com/squareup/tooling/support/android/SquareProjectExtractorImpl.kt
@@ -32,6 +32,9 @@ internal class SquareProjectExtractorImpl : SquareProjectExtractor {
       // Android library plugin logic
       project.plugins.hasPlugin("com.android.library") -> project.extractLibraryModuleProject()
 
+      // Android test plugin logic
+      project.plugins.hasPlugin("com.android.test") -> project.extractTestModuleProject()
+
       else -> null
     }
   }

--- a/tooling/support/android/src/test/kotlin/com/squareup/tooling/support/android/SquareProjectModelBuilderTest.kt
+++ b/tooling/support/android/src/test/kotlin/com/squareup/tooling/support/android/SquareProjectModelBuilderTest.kt
@@ -94,6 +94,40 @@ class SquareProjectModelBuilderTest {
   }
 
   @Test
+  fun `Ensure android test constructs SquareProject`() {
+    val projectExtractor = SquareProjectExtractorImpl()
+
+    val rootProject = ProjectBuilder
+      .builder()
+      .withName("com.squareup")
+      .build()
+
+    val childProject = ProjectBuilder
+      .builder()
+      .withName("test")
+      .withParent(rootProject)
+      .build()
+
+    val testProject = ProjectBuilder
+      .builder()
+      .withName("lib")
+      .withParent(childProject)
+      .build()
+
+    testProject.plugins.apply("com.android.test")
+
+    val result = projectExtractor.extractSquareProject(testProject)
+    val expected = SquareProject(
+      name = "lib",
+      namespace = "com.squareup",
+      pathToProject = "test/lib",
+      pluginUsed = "android-test",
+      variants = emptyMap()
+    )
+    assertEquals(expected, result)
+  }
+
+  @Test
   fun `Ensure no plugins returns null`() {
     val projectExtractor = SquareProjectExtractorImpl()
 

--- a/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
+++ b/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
@@ -42,9 +42,11 @@ private class SquareProjectModelBuilderImpl : SquareProjectModelBuilder {
     return modelName == SquareProject::class.java.name
   }
 
-  override fun buildAll(modelName: String, project: Project): Any? {
+  override fun buildAll(modelName: String, project: Project): Any {
     if (modelName == SquareProject::class.java.name) {
-      return extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }
+      return requireNotNull(extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }) {
+        "No known ${SquareProject::class.java.name} found for project ${project.path}"
+      }
     }
 
     // If this is used for any other project types, or for some other model type,

--- a/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
+++ b/tooling/support/src/main/kotlin/com/squareup/tooling/support/builder/SquareProjectModelBuilder.kt
@@ -42,11 +42,9 @@ private class SquareProjectModelBuilderImpl : SquareProjectModelBuilder {
     return modelName == SquareProject::class.java.name
   }
 
-  override fun buildAll(modelName: String, project: Project): Any {
+  override fun buildAll(modelName: String, project: Project): Any? {
     if (modelName == SquareProject::class.java.name) {
-      return requireNotNull(extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }) {
-        "No known ${SquareProject::class.java.name} found for project ${project.path}"
-      }
+      return extractors.firstNotNullOfOrNull { it.extractSquareProject(project) }
     }
 
     // If this is used for any other project types, or for some other model type,


### PR DESCRIPTION
This will allow projects with the `com.android.test` plugin to be evaluated with affected-paths. Previously, these projects were evaluated as `JVM` projects, and did not generate the proper `SquareProject` object.