### PR TITLE
Allow build scans to run on affected-paths runs with Gradle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- `affected-paths-core`: Add in flag for enabling build scans on affected-paths runs
 
 ## v0.1.3
 - `affected-paths-core`: Fix custom Gradle flags not being properly set

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/options/BaseConfigurationOptions.kt
@@ -127,4 +127,11 @@ internal class BaseConfigurationOptions {
   )
   var gradleInstallationPath: Path? = null
     internal set
+
+  @Option(
+    names = ["--build-scan"],
+    description = ["Capture the Gradle build scan"]
+  )
+  var gradleBuildScan: Boolean = false
+    internal set
 }

--- a/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
+++ b/affected-paths/app/src/main/kotlin/com/squareup/affected/paths/app/utils/CoreOptionsUtils.kt
@@ -34,5 +34,6 @@ internal fun BaseConfigurationOptions.toCoreOptions(): CoreOptions {
     autoInjectPlugin = autoInject,
     changedFiles = changedFiles,
     gradleInstallationPath = gradleInstallationPath,
+    useBuildScan = gradleBuildScan
   )
 }

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreAnalyzer.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreAnalyzer.kt
@@ -96,6 +96,9 @@ public class CoreAnalyzer @JvmOverloads constructor(private val coreOptions: Cor
             )
           )
           actionExecutor.withCancellationToken(cancellationTokenSource.token())
+          if (coreOptions.useBuildScan) {
+            actionExecutor.forTasks(emptyList())
+          }
           actionExecutor.addArguments(coreOptions.gradleArgs)
           actionExecutor.addJvmArguments(coreOptions.jvmArgs)
 

--- a/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
+++ b/affected-paths/core/src/main/kotlin/com/squareup/affected/paths/core/CoreOptions.kt
@@ -72,6 +72,14 @@ public data class CoreOptions @JvmOverloads constructor(
 
   /** Pass in a custom Gradle installation, instead of using the build distribution */
   val gradleInstallationPath: Path? = null,
+
+  /**
+   * Add the build scan flag to the tooling.
+   *
+   * **Note**: This will cause the default tasks of a build to run.
+   */
+
+  val useBuildScan: Boolean = false,
 ) {
 
   init {
@@ -122,6 +130,9 @@ public data class CoreOptions @JvmOverloads constructor(
           deleteOnExit()
         }.absolutePath
       )
+    }
+    if (useBuildScan) {
+      add("--scan")
     }
   }
 }


### PR DESCRIPTION
When querying for models only, Gradle Tooling API does not trigger build scans to occur. This will provide an empty task list along with including the `--scan` flag when running the model query on Gradle.