### PR TITLE
Fix serialVersionUID field names

### DIFF
--- a/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareDependency.kt
+++ b/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareDependency.kt
@@ -34,6 +34,6 @@ public interface SquareDependency : Serializable {
   public val tags: Set<String>
 
   public companion object {
-    private const val serialVersionUid: Long = 1L
+    private const val serialVersionUID: Long = 1L
   }
 }

--- a/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareProject.kt
+++ b/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareProject.kt
@@ -37,6 +37,6 @@ public interface SquareProject : Serializable {
   public val variants: Map<String, SquareVariantConfiguration>
 
   public companion object {
-    private const val serialVersionUid: Long = 1L
+    private const val serialVersionUID: Long = 1L
   }
 }

--- a/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareTestConfiguration.kt
+++ b/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareTestConfiguration.kt
@@ -30,6 +30,6 @@ public interface SquareTestConfiguration : Serializable {
   public val deps: Set<SquareDependency>
 
   public companion object {
-    private const val serialVersionUid: Long = 1L
+    private const val serialVersionUID: Long = 1L
   }
 }

--- a/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareVariantConfiguration.kt
+++ b/tooling/models/src/main/kotlin/com/squareup/tooling/models/SquareVariantConfiguration.kt
@@ -32,6 +32,6 @@ public interface SquareVariantConfiguration : Serializable {
   public val tests: Map<String, SquareTestConfiguration>
 
   public companion object {
-    private const val serialVersionUid: Long = 1L
+    private const val serialVersionUID: Long = 1L
   }
 }


### PR DESCRIPTION
`serialVersionUID` field name is case-sensitive. Existing code uses incorrect `serialVersionUid` (vs "UID") name, which results in not being able to deserialize these object if they are persisted to disk, because serialVersionUID's do not match.

This bug was noticed updating an internal fork of this library that stores `List<SquareProject>` to a cache to avoid having to init & configure our gradle project between affected-paths tool executions on similar code.